### PR TITLE
STO-1985 Fix huge size issue when releasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "typings": "dist/index.d.ts",
     "files": [
         "android",
-        "!android/build",
         "ios",
-        "!ios/build",
         "dist",
         "RNFastImage.podspec"
     ],


### PR DESCRIPTION
It has been noticed recently that picnic's version of react-native-fast-image package has a huge size when its released (around 50 mb). After investigation we have found that this is a yarn related issue that happens when having a negative expression in “files” entry of package.json.

This yarn issue is still open and not yet fixed, you read more about it here: https://github.com/yarnpkg/yarn/issues/8332

The fix is simply to remove the negative expressions in “files” entry of package.json, and we verified that this is a safe change.