### PR TITLE
STO-2145 Catch IllegalArgumentExceptions when trying to animate

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewWithUrl.java
@@ -15,8 +15,10 @@ class FastImageViewWithUrl extends AppCompatImageView {
         if (this.getDrawable() instanceof WebpDrawable) {
             WebpDrawable drawable = (WebpDrawable) this.getDrawable();
             if (!drawable.isRunning()) {
-                drawable.stop();
-                drawable.startFromFirstFrame();
+                try {
+                  drawable.stop();
+                  drawable.startFromFirstFrame();
+                } catch (IllegalArgumentException ignored) {}
             }
         }
     }


### PR DESCRIPTION
We should catch the exception “IllegalArgumentException: Can't restart a running animation“ from react-native-fast-image since we can’t easily reproduce the issue and it is better for the animation not to play instead of crashing the app for the user. The fix will be similar to https://github.com/PicnicSupermarket/picnic-android/pull/2424/files