### PR TITLE
STO-6241 Reset the Glide request manager context when recycling a view

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -122,6 +122,9 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
 
         Drawable placeholderDrawable = view.getPlaceholderDrawable();
 
+        if (isValidContextForGlide(view.getContext())) {
+            requestManager = Glide.with(view.getContext());
+        }
         if (requestManager != null) {
             requestManager
                     // This will make this work for remote and local images. e.g.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-fast-image",
-    "version": "8.5.11-picnic.17",
+    "version": "8.5.11-picnic.19",
     "description": "🚩 FastImage, performant React Native image component.",
     "keywords": [
         "cache",


### PR DESCRIPTION
When a view is created the request manager based on that context is also created:
```
    @Override
    protected FastImageViewWithUrl createViewInstance(ThemedReactContext reactContext) {
        if (isValidContextForGlide(reactContext)) {
            requestManager = Glide.with(reactContext);
        }

        return new FastImageViewWithUrl(reactContext);
    }
```

However when recycling the view after a suspense refresh it seems that the previous context is not always available which results on the request for the new image to not be processed. 
In order to fix this issue, we are reseting the request manager to be able to support the new context.